### PR TITLE
Adicionar a navigation controller e retirar uma última parte do storyboard

### DIFF
--- a/SoundBook/Delegates/SceneDelegate.swift
+++ b/SoundBook/Delegates/SceneDelegate.swift
@@ -16,8 +16,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        let window = UIWindow(windowScene: windowScene)
+                    window.rootViewController = UINavigationController(rootViewController: MainViewController())
+                    window.makeKeyAndVisible()
+                    self.window = window
     }
+    
 
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.

--- a/SoundBook/Info.plist
+++ b/SoundBook/Info.plist
@@ -33,8 +33,6 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION

### Motivation
Necessidade da existência de uma Navigation bar, e necessidade de retirar uma última parte do storyboard que estava quebrando o app.

### Modifications
Adição da Navigation bar e retirada de um último atributo do storyboard

### Results
Navigation bar implementada e código rodando sem erros.